### PR TITLE
fix: handlebars import

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import logger from './lib/logger';
 import sqlite from './lib/sqlite';
 import express from 'express';
 import bodyParser from 'body-parser';
-import exphbs from 'express-handlebars';
+import * as exphbs from 'express-handlebars';
 import { OAuthRoute } from './routes/oauth';
 import { PPCommandRoute } from './routes/pp-command';
 import { InteractivityRoute } from './routes/interactivity';


### PR DESCRIPTION
fixes an issue to start the server, handlebars engine was undefined.

```
"msg":"Could not boot","err":{"type":"TypeError","message":"Cannot read properties of undefined (reading 'engine')"
```